### PR TITLE
Add dependabot configuration for keeping dependencies current

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
This change adds a Dependabot[1] configuration to keep dependencies up-to-date. The routine will check files like https://github.com/DLR-RM/python-jsonconversion/blob/master/pyproject.toml for any updates.

[1] https://docs.github.com/en/code-security/dependabot