### PR TITLE
pyproject.toml: Remove pytest[-runner] deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,9 +26,7 @@ classifiers = [
     "Topic :: Utilities"
 ]
 dependencies = [
-    "pytest-runner>=6.0.0",
     "numpy<2.0.0,>=1.22.4",
-    "pytest>=6.0.0,<7.0.0",
 ]
 license = {text = "BSD"}
 requires-python = ">=3.7"


### PR DESCRIPTION
The actual wheel does not depend on `pytest-[runner]`. And the tests work fine with pytest v8.3.1.